### PR TITLE
Fix `request`/`requests` typo in bidi stream

### DIFF
--- a/lib/opentelemetry/instrumentation/grpc/interceptors/client.rb
+++ b/lib/opentelemetry/instrumentation/grpc/interceptors/client.rb
@@ -17,7 +17,7 @@ module OpenTelemetry
             call(type: "server_streamer", requests: [request], call: call, method: method, metadata: metadata, &blk)
           end
 
-          def bidi_streamer(request: nil, call: nil, method: nil, metadata: nil, &blk)
+          def bidi_streamer(requests: nil, call: nil, method: nil, metadata: nil, &blk)
             call(type: "client_streamer", requests: requests, call: call, method: method, metadata: metadata, &blk)
           end
 


### PR DESCRIPTION
Updates the signature for `bidi_streamer` to use the keyword `request`
rather than `requests`.  This is in accordance with the signatures
specified in `GRPC::Interceptor::ClientInterceptor`. [1]

The previous use of `request` as a keyword seems to be a bug.  It would
throw an exception when any bidi method is invoked via this interceptor.

[1] https://github.com/grpc/grpc/blob/v1.66.1/src/ruby/lib/grpc/generic/interceptors.rb#L86