### PR TITLE
Config to skip OpenTelemetry.propagation.inject(metadata)

### DIFF
--- a/lib/opentelemetry/instrumentation/grpc/instrumentation.rb
+++ b/lib/opentelemetry/instrumentation/grpc/instrumentation.rb
@@ -11,6 +11,7 @@ module OpenTelemetry
 
         option :allowed_metadata_headers, default: [], validate: :array
         option :peer_service, default: nil, validate: :string
+        option :skip_telemetry_propagation, default: false, validate: :boolean
 
         present do
           defined?(::GRPC)

--- a/lib/opentelemetry/instrumentation/grpc/interceptors/client.rb
+++ b/lib/opentelemetry/instrumentation/grpc/interceptors/client.rb
@@ -48,7 +48,7 @@ module OpenTelemetry
               attributes: attributes,
               kind: OpenTelemetry::Trace::SpanKind::CLIENT
             ) do |span|
-              OpenTelemetry.propagation.inject(metadata)
+              OpenTelemetry.propagation.inject(metadata) unless instrumentation_config[:skip_telemetry_propagation]
               yield.tap do
                 span&.set_attribute(OpenTelemetry::SemanticConventions::Trace::RPC_GRPC_STATUS_CODE, 0)
               end


### PR DESCRIPTION
An alternative to https://github.com/hibachrach/opentelemetry-instrumentation-grpc/pull/3 that's probably cleaner. 